### PR TITLE
Errors with --watch #ok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+
+node_modules
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 node_modules
 npm-debug.log
+
+/test/core.out.js

--- a/lib/ki_run.js
+++ b/lib/ki_run.js
@@ -43,7 +43,7 @@ exports.run = function() {
   var file;
   if (infile) {
     file = fs.readFileSync(infile, 'utf8');
-  } 
+  }
   else if (argv._.length === 0) {
     console.log(require("optimist").help());
     return 0;
@@ -55,7 +55,7 @@ exports.run = function() {
   if (autonomous) {
     moriSrc = fs.readFileSync(path.join(path.dirname(fs.realpathSync(__filename)),'../node_modules/mori/mori.js'), 'utf8');
   }
-  
+
   var parseIncludedRules = function(includes) {
     var includeFiles = includes.map(function(path) {
       return fs.readFileSync(path, 'utf8');
@@ -105,7 +105,7 @@ exports.run = function() {
       return 0;
     }
     catch (e) {
-      console.log(e);
+      console.error(e);
       return 1;
     }
   }
@@ -121,11 +121,11 @@ exports.run = function() {
     }
     try {
       compile(src,options,uglify,fs);
-    } 
-    catch (e) {
-      console.log(e);
+      console.log('Compiled',infile);
     }
-    console.log('Compiled',infile);
+    catch (e) {
+      console.error(e);
+    }
   }
 
   var onIncludedFileChanged = function() {
@@ -137,7 +137,7 @@ exports.run = function() {
 
   if (watch) {
     var watchOptions = {
-      persistent: true, 
+      persistent: true,
       interval: 1000
     };
     fs.watchFile(infile, watchOptions, onFileChanged);
@@ -149,4 +149,3 @@ exports.run = function() {
 
   return ret;
 }
-

--- a/lib/ki_run.js
+++ b/lib/ki_run.js
@@ -58,11 +58,17 @@ exports.run = function() {
 
   var parseIncludedRules = function(includes) {
     var includeFiles = includes.map(function(path) {
-      return fs.readFileSync(path, 'utf8');
+      return {"path": path, "file": fs.readFileSync(path, 'utf8')};
     });
 
-    var rules = includeFiles.map(function(includeFile) {
-      return ki.parseMacros(includeFile);
+    var rules = includeFiles.map(function(include) {
+      try {
+        return ki.parseMacros(include.file);
+      }
+      catch (e) {
+        // console.error(e); // not useful error, so far
+        throw new Error("Failed to parse " + include.path);
+      }
     });
 
     return rules;
@@ -137,7 +143,7 @@ exports.run = function() {
       rules = parseIncludedRules(includes);
     }
     catch (e) {
-      console.error("Failed to parse", includes);
+      console.error(e);
       return; // don't compile if parseIncludedRules throws
     }
     var module = ki.joinModule(file,ki_core,rules);

--- a/lib/ki_run.js
+++ b/lib/ki_run.js
@@ -120,8 +120,12 @@ exports.run = function() {
       options.modules = sweet.loadModule(module);
     }
     try {
-      compile(src,options,uglify,fs);
-      console.log('Compiled',infile);
+      if(compile(src,options,uglify,fs) === 0) {
+        console.log('Compiled', infile);
+      }
+      else {
+        console.error('Failed to compile', infile);
+      }
     }
     catch (e) {
       console.error(e);
@@ -129,7 +133,13 @@ exports.run = function() {
   }
 
   var onIncludedFileChanged = function() {
-    rules = parseIncludedRules(includes);
+    try {
+      rules = parseIncludedRules(includes);
+    }
+    catch (e) {
+      console.error("Failed to parse", includes);
+      return; // don't compile if parseIncludedRules throws
+    }
     var module = ki.joinModule(file,ki_core,rules);
     options.modules = sweet.loadModule(module);
     onFileChanged();


### PR DESCRIPTION
I got sold on using the upgraded `--watch` option (as it's faster), but that means I can't count on the exit code.  This is a patch to send errors to `console.error` instead of `console.log` so they can be handled separately even though they often go to the same place.  Saying 'Compiled'  only if output is generated - there is 'Failed to compile' counterpart.  There is always something sent to `stdout` or  `stderr` - so I can toggle (e.g. AnyBar) a green or red light respectively.  This affects only the cli onChange events for the source / include files.  The idea is that you start with something that parses / compile to begin with and you save one more or less parenthesis and the code continues to be watched rather than throwing an uncaught exception.  I left the `lib/ki.js` untouched - it doesn't affect my workflow and I didn't want to make unnecessary guesses.  We also get to know the first file containing macros that can't parse (with or without `-w`), in which case there is no further compilation attempted.
